### PR TITLE
Changed CloudMapper operator file selection to match other operator file selection

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
@@ -53,14 +53,12 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
     // Convert the Scala fastQFiles into a file path
     val (filepath, fileDesc) = determineFilePathOrDatasetFile(Some(fastQFiles))
     val fastQFilePath = if (filepath != null) filepath else fileDesc.asFile().toPath.toString
-    Console.println(fastQFilePath)
 
     // Convert the Scala referenceGenomes list to a Python list format
     val pythonReferenceGenomes = referenceGenomes
       .map(_.referenceGenome.getName)
       .map(name => s"'$name'")
       .mkString("[", ", ", "]")
-    Console.println(pythonReferenceGenomes)
 
     // Convert the Scala referenceGenomes list to a Python list format for FASTA files
     val pythonFastaFiles = referenceGenomes
@@ -71,7 +69,6 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
         s"open(r'$fastAFilePath', 'rb')"
       })
       .mkString("[", ", ", "]")
-    Console.println(pythonFastaFiles)
 
     // Extract GTF file if exists for 'Others'
     val pythonGtfFile = referenceGenomes
@@ -83,7 +80,6 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
         s"open(r'$gtfFilePath', 'rb')"
       })
       .getOrElse("")
-    Console.println(pythonGtfFile )
 
     s"""from pytexera import *
        |

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
@@ -1,17 +1,14 @@
 package edu.uci.ics.texera.workflow.operators.source.scan
 
 import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
-import com.kjetland.jackson.jsonSchema.annotations.{
-  JsonSchemaInject,
-  JsonSchemaString,
-  JsonSchemaTitle
-}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaString, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.texera.workflow.common.metadata.annotations.HideAnnotation
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.text.TextSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.util.OperatorFilePathUtils
 
 @JsonIgnoreProperties(value = Array("limit", "offset", "fileEncoding"))
 class FileScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
@@ -47,7 +44,7 @@ class FileScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     PhysicalOp
       .sourcePhysicalOp(
         workflowId,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
@@ -87,20 +87,6 @@ abstract class ScanSourceOpDesc extends SourceOperatorDescriptor {
 
   def inferSchema(): Schema
 
-  // resolve the file path based on whether the user system is enabled
-  // it will check for the presence of the given filePath/Desc
-  def determineFilePathOrDatasetFile(): (String, DatasetFileDocument) = {
-    if (AmberConfig.isUserSystemEnabled) {
-      val file = datasetFile.getOrElse(
-        throw new RuntimeException("Dataset file descriptor is not provided.")
-      )
-      (null, file)
-    } else {
-      val filepath = filePath.getOrElse(throw new RuntimeException("File path is not provided."))
-      (filepath, null)
-    }
-  }
-
   override def equals(that: Any): Boolean =
     EqualsBuilder.reflectionEquals(this, that, "context", "filePath")
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, Workf
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferSchemaFromRows
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.util.OperatorFilePathUtils
 
 import java.io.{File, FileInputStream, IOException, InputStreamReader}
 
@@ -37,7 +38,7 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
     if (customDelimiter.isEmpty || customDelimiter.get.isEmpty)
       customDelimiter = Option(",")
 
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     PhysicalOp
       .sourcePhysicalOp(
         workflowId,
@@ -74,7 +75,7 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
       return null
     }
 
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val stream =
       if (filepath != null) {
         new FileInputStream(new File(filepath))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, Workf
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferSchemaFromRows
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.util.OperatorFilePathUtils
 
 import java.io.{File, IOException}
 
@@ -39,7 +40,7 @@ class ParallelCSVScanSourceOpDesc extends ScanSourceOpDesc {
 
     // here, the stream requires to be seekable, so datasetFileDesc creates a temp file here
     // TODO: consider a better way
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val file =
       if (filepath == null) {
         fileDesc.asFile()
@@ -86,7 +87,7 @@ class ParallelCSVScanSourceOpDesc extends ScanSourceOpDesc {
     if (customDelimiter.isEmpty) {
       return null
     }
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val file =
       if (filepath == null) {
         fileDesc.asFile()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csvOld/CSVOldScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csvOld/CSVOldScanSourceOpDesc.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, Workf
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferSchemaFromRows
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.util.OperatorFilePathUtils
 
 import java.io.{File, IOException}
 
@@ -37,7 +38,7 @@ class CSVOldScanSourceOpDesc extends ScanSourceOpDesc {
     if (customDelimiter.get.isEmpty)
       customDelimiter = Option(",")
 
-    val (filepath, datasetFileDocument) = determineFilePathOrDatasetFile()
+    val (filepath, datasetFileDocument) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     // for CSVOldScanSourceOpDesc, it requires the full File presence when execute, so use temp file here
     // TODO: figure out a better way
     val path =
@@ -81,7 +82,7 @@ class CSVOldScanSourceOpDesc extends ScanSourceOpDesc {
     if (customDelimiter.isEmpty) {
       return null
     }
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val file =
       if (filepath != null) {
         new File(filepath)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
@@ -11,6 +11,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferS
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
 import edu.uci.ics.texera.workflow.operators.source.scan.json.JSONUtil.JSONToMap
+import edu.uci.ics.texera.workflow.operators.util.OperatorFilePathUtils
 
 import java.io.{BufferedReader, FileInputStream, IOException, InputStream, InputStreamReader}
 import scala.collection.mutable.ArrayBuffer
@@ -37,7 +38,7 @@ class JSONLScanSourceOpDesc extends ScanSourceOpDesc {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val stream = createInputStream(filepath, fileDesc)
     // count lines and partition the task to each worker
     val reader = new BufferedReader(
@@ -85,7 +86,7 @@ class JSONLScanSourceOpDesc extends ScanSourceOpDesc {
     */
   @Override
   def inferSchema(): Schema = {
-    val (filepath, fileDesc) = determineFilePathOrDatasetFile()
+    val (filepath, fileDesc) = OperatorFilePathUtils.determineFilePathOrDatasetFile(this.fileName)
     val stream = createInputStream(filepath, fileDesc)
     val reader = new BufferedReader(new InputStreamReader(stream, fileEncoding.getCharset))
     var fieldNames = Set[String]()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/util/OperatorFilePathUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/util/OperatorFilePathUtils.scala
@@ -1,0 +1,25 @@
+package edu.uci.ics.texera.workflow.operators.util
+
+import edu.uci.ics.amber.engine.common.AmberConfig
+import edu.uci.ics.amber.engine.common.storage.DatasetFileDocument
+
+import java.nio.file.Paths
+
+object OperatorFilePathUtils {
+  // resolve the file path based on whether the user system is enabled
+  // it will check for the presence of the given filePath/Desc based on fileName
+  def determineFilePathOrDatasetFile(fileName: Option[String]): (String, DatasetFileDocument) = {
+    if (AmberConfig.isUserSystemEnabled) {
+      // if user system is defined, a datasetFileDesc will be initialized, which is the handle of reading file from the dataset
+      val datasetFile = Some(new DatasetFileDocument(Paths.get(fileName.get)))
+      val file = datasetFile.getOrElse(
+        throw new RuntimeException("Dataset file descriptor is not provided.")
+      )
+      (null, file)
+    } else {
+      // otherwise, the fileName will be inputted by user, which is the filePath.
+      val filepath = fileName.getOrElse(throw new RuntimeException("File path is not provided."))
+      (filepath, null)
+    }
+  }
+}

--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -430,8 +430,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
         };
       }
 
-      // if the title is fileName, then change it to custom autocomplete input template
-      if (mappedField.key == "fileName") {
+      // if the title is fileName, fastQFiles, fastAFiles, or gtfFile, then change it to custom autocomplete input template
+      if (mappedField.key == "fileName" || mappedField.key == "fastQFiles" || mappedField.key == "fastAFiles" || mappedField.key == "gtfFile") {
         mappedField.type = "inputautocomplete";
       }
 


### PR DESCRIPTION
Allows users to select files from the uploaded datasets, mimicking the functionality of other file selectors.

![image](https://github.com/user-attachments/assets/7346399f-8819-4cde-9bc4-115d6c64e20e)