### PR TITLE
Asynchronous communication between CloudMapper Operator and CloudMapper Service

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
@@ -100,7 +100,7 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
        |
        |        # Send the POST request to start the job
        |        response = requests.post("${AmberConfig.clusterLauncherServiceTarget}/api/job/create",
-       |                                 data=form_data, files=files, timeout=0.5)
+       |                                 data=form_data, files=files)
        |
        |        # Extract the job ID from the initial response
        |        job_id = response.json().get("job_id")
@@ -124,7 +124,8 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
        |            yield
        |
        |        # Request to download the ZIP file after the job is completed
-       |        download_response = requests.get(f'${AmberConfig.clusterLauncherServiceTarget}/api/job/download/{job_id}')
+       |        download_response = requests.get(f'${AmberConfig.clusterLauncherServiceTarget}/api/job/download/{job_id}',
+       |                                         params={'cid': str(${clusterId})})
        |
        |        if download_response.status_code == 200:
        |            # Read the ZIP file from the response content

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cloudmapper/CloudMapperSourceOpDesc.scala
@@ -50,10 +50,7 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
        |
        |    @overrides
        |    def produce(self) -> Iterator[Union[TupleLike, TableLike, None]]:
-       |        import requests, zipfile, io
-       |
-       |        # Set the URL to the Go endpoint
-       |        url = "${AmberConfig.clusterLauncherServiceTarget}/api/job/create"
+       |        import requests, zipfile, io, time
        |
        |        def create_job_form_data(cluster_id, job_form):
        |            form_data = {
@@ -101,19 +98,47 @@ class CloudMapperSourceOpDesc extends PythonSourceOperatorDescriptor {
        |        # Create form data and files based on the provided job_form
        |        form_data, files = create_job_form_data(${clusterId}, job_form)
        |
-       |        # Send the POST request to the Go program
-       |        response = requests.post(url, data=form_data, files=files)
+       |        # Send the POST request to start the job
+       |        response = requests.post("${AmberConfig.clusterLauncherServiceTarget}/api/job/create",
+       |                                 data=form_data, files=files, timeout=0.5)
        |
-       |        if response.status_code == 200:
-       |            zip_file = zipfile.ZipFile(io.BytesIO(response.content))
+       |        # Extract the job ID from the initial response
+       |        job_id = response.json().get("job_id")
        |
+       |        # Poll until the job is finished
+       |        while True:
+       |            # Poll the status endpoint
+       |            status_response = requests.get(f'${AmberConfig.clusterLauncherServiceTarget}/api/job/status/{job_id}')
+       |            status = status_response.json().get("status")
+       |
+       |            if status == "finished":
+       |                print("Job finished! Downloading the result...")
+       |                break
+       |            elif status == "failed":
+       |                print("Job failed.")
+       |                yield {'features': None, 'barcodes': None, 'matrix': None}
+       |                return
+       |
+       |            print("Job is still processing...")
+       |            time.sleep(0.5)
+       |            yield
+       |
+       |        # Request to download the ZIP file after the job is completed
+       |        download_response = requests.get(f'${AmberConfig.clusterLauncherServiceTarget}/api/job/download/{job_id}')
+       |
+       |        if download_response.status_code == 200:
+       |            # Read the ZIP file from the response content
+       |            zip_file = zipfile.ZipFile(io.BytesIO(download_response.content))
+       |
+       |            # Extract file contents from the ZIP file
        |            features_content = zip_file.read('features.tsv')
        |            barcodes_content = zip_file.read('barcodes.tsv')
        |            matrix_content = zip_file.read('matrix.mtx')
+       |
        |            yield {'features': features_content, 'barcodes': barcodes_content, 'matrix': matrix_content}
        |        else:
-       |            print(f"Failed to get the files. Status Code: {response.status_code}")
-       |            print(f"Response Text: {response.text}")
+       |            print(f"Failed to get the files. Status Code: {download_response.status_code}")
+       |            print(f"Response Text: {download_response.text}")
        |            yield {'features': None, 'barcodes': None, 'matrix': None}
     """.stripMargin
   }


### PR DESCRIPTION
This PR enhances the Python script of the CloudMapper Operator to improve client-server communication and job management by implementing the following changes:
1. Polling for Job Status: The script now continuously polls the `/api/job/status/{job_id}` endpoint to monitor the status of a job until it is completed. This non-blocking approach allows for more responsive interactions, such as pausing the workflow.
2. Downloading Results with Query Parameters: The script sends the `cid (cluster ID)` as a query parameter to the `/api/job/download/{job_id}` endpoint, ensuring that the correct result ZIP file is downloaded.

#### Rationale for Changes
- The updated endpoints provide a more streamlined and efficient way for the client to interact with the server, check job status, and download results. The previous implementation blocked the Python script, preventing responsive user interactions, such as pausing or resuming workflows.
- Separating the job status monitoring from file download operations allows for more robust and manageable error handling, reducing potential issues and improving reliability.

![clusters_tab-Page-4 (2)](https://github.com/user-attachments/assets/211d56ba-f4bb-4115-90e5-7717db45b719)


#### How to Test
Need to test with this PR: https://github.com/Texera/cloudmapper/pull/18
