### PR TITLE
Changed cluster statuses that end in ING to be a loading symbol

### DIFF
--- a/core/gui/src/app/dashboard/component/user/cluster/cluster.component.ts
+++ b/core/gui/src/app/dashboard/component/user/cluster/cluster.component.ts
@@ -118,15 +118,15 @@ export class ClusterComponent implements OnInit {
     switch(status){
       case "LAUNCHING":
       case "RESUMING":
-        return ["play-circle", "orange"];
+        return ["loading", "green"];
       case "PAUSING":
-        return ["pause-circle", "orange"];
+        return ["loading", "orange"];
       case "LAUNCHED":
         return ["check-circle", "green"];
       case "PAUSED":
         return ["pause-circle", "gray"];
       case "TERMINATING":
-        return ["minus-circle", "orange"];
+        return ["loading", "red"];
       case "TERMINATED":
       case "FAILED":
         return ["minus-circle", "red"];


### PR DESCRIPTION
Changes all statuses that including RESUMING, PAUSING, LAUNCHING, and TERMINATING to be loading icons so that users can more easily determine if a cluster is ready.