### PR TITLE
Change name from Clusters to Starsolo Clusters

### DIFF
--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -85,7 +85,7 @@
         <span
           nz-icon
           nzType="cluster"></span>
-        <span>Clusters</span>
+        <span>Starsolo Clusters</span>
       </li>
       <li
         *ngIf="isAdmin"

--- a/core/gui/src/app/dashboard/component/user/cluster/cluster.component.html
+++ b/core/gui/src/app/dashboard/component/user/cluster/cluster.component.html
@@ -1,6 +1,6 @@
 <div class="section-container subsection-grid-container">
   <nz-card class="section-title">
-    <h2 class="page-title">Clusters</h2>
+    <h2 class="page-title">Starsolo Clusters</h2>
 
     <button
       (click)="openClusterManagementModal()"

--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -431,7 +431,12 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
       }
 
       // if the title is fileName, fastQFiles, fastAFiles, or gtfFile, then change it to custom autocomplete input template
-      if (mappedField.key == "fileName" || mappedField.key == "fastQFiles" || mappedField.key == "fastAFiles" || mappedField.key == "gtfFile") {
+      if (
+        mappedField.key == "fileName" ||
+        mappedField.key == "fastQFiles" ||
+        mappedField.key == "fastAFiles" ||
+        mappedField.key == "gtfFile"
+      ) {
         mappedField.type = "inputautocomplete";
       }
 


### PR DESCRIPTION
This PR changes the name from Clusters to Starsolo Clusters. The reason is because the current cluster is specifically for sequence alignment. Later, we will change the name back to "Clusters" when the cluster becomes a general-purpose cluster. 